### PR TITLE
enable passing FQDN via environment variable

### DIFF
--- a/example/docker-compose.yml
+++ b/example/docker-compose.yml
@@ -4,6 +4,7 @@ services:
     image: osixia/openldap:1.5.0
     container_name: openldap
     environment:
+      #FQDN: "ldap-server.example.org"
       LDAP_LOG_LEVEL: "256"
       LDAP_ORGANISATION: "Example Inc."
       LDAP_DOMAIN: "example.org"
@@ -39,9 +40,10 @@ services:
     ports:
       - "389:389"
       - "636:636"
-    # For replication to work correctly, domainname and hostname must be
+    # For replication to work correctly, either domainname and hostname must be
     # set correctly so that "hostname"."domainname" equates to the
-    # fully-qualified domain name for the host.
+    # fully-qualified domain name for the host
+    # or the FQDN is provided directly as environment variable (see above).
     domainname: "example.org"
     hostname: "ldap-server"
   phpldapadmin:

--- a/image/service/slapd/process.sh
+++ b/image/service/slapd/process.sh
@@ -9,8 +9,10 @@ log-helper level eq trace && set -x
 # see https://github.com/docker/docker/issues/8231
 ulimit -n $LDAP_NOFILE
 
-# Call hostname to determine the fully qualified domain name. We want OpenLDAP to listen
-# to the named host for the ldap:// and ldaps:// protocols.
-FQDN="$(/bin/hostname --fqdn)"
+# We want OpenLDAP to listen to the named host for the ldap:// and ldaps:// protocols.
+if [ -z "$FQDN" ]; then
+  # Only call hostname if the fully qualified domain name wasn't provided as environment variable.
+  FQDN="$(/bin/hostname --fqdn)"
+fi
 HOST_PARAM="ldap://$FQDN:$LDAP_PORT ldaps://$FQDN:$LDAPS_PORT"
 exec /usr/sbin/slapd -h "$HOST_PARAM ldapi:///" -u openldap -g openldap -d "$LDAP_LOG_LEVEL"

--- a/image/service/slapd/startup.sh
+++ b/image/service/slapd/startup.sh
@@ -567,8 +567,10 @@ ln -sf ${CONTAINER_SERVICE_DIR}/slapd/assets/ldap.conf /etc/ldap/ldap.conf
 # force OpenLDAP to listen on all interfaces
 # We need to make sure that /etc/hosts continues to include the
 # fully-qualified domain name and not just the specified hostname.
-# Without the FQDN, /bin/hostname --fqdn stops working.
-FQDN="$(/bin/hostname --fqdn)"
+if [ -z "$FQDN" ]; then
+  # Only call hostname if the fully qualified domain name wasn't provided as environment variable.
+  FQDN="$(/bin/hostname --fqdn)"
+fi
 if [ "$FQDN" != "$HOSTNAME" ]; then
     FQDN_PARAM="$FQDN"
 else


### PR DESCRIPTION
I tried to deploy this image using Docker secrets via `docker stack deploy` on a Linux server but unfortunately that doesn't support the parameter `domainname` (see [here](https://github.com/docker/for-linux/issues/113)). Therefore, I couldn't configure replication as supported by [this PR](https://github.com/osixia/docker-openldap/pull/420/). 

To solve this problem, I changed the scripts to use `FQDN` if it is set instead of calling `hostname`. 