### PR TITLE
Fix download URL in Dockerfile

### DIFF
--- a/image/Dockerfile
+++ b/image/Dockerfile
@@ -37,7 +37,7 @@ RUN echo "path-include /usr/share/doc/krb5*" >> /etc/dpkg/dpkg.cfg.d/docker && a
     slapd=${OPENLDAP_PACKAGE_VERSION}\* \
     slapd-contrib=${OPENLDAP_PACKAGE_VERSION}\* \
     krb5-kdc-ldap \
-    && curl -o pqchecker.deb -SL http://www.meddeb.net/pub/pqchecker/deb/8/pqchecker_${PQCHECKER_VERSION}_amd64.deb \
+    && curl -o pqchecker.deb -SL http://meddeb.net/pub/pqchecker/deb/8/pqchecker_${PQCHECKER_VERSION}_amd64.deb \
     && echo "${PQCHECKER_MD5} *pqchecker.deb" | md5sum -c - \
     && dpkg -i pqchecker.deb \
     && rm pqchecker.deb \


### PR DESCRIPTION
The pqchecker download URL redirects to HTTPS, but the TLS certificate is only valid for meddeb.net at the time of writing (without the www. prefix), so curl fails. This PR changes the download URL to remove the www. prefix and fix the curl download of pqchecker.