### PR TITLE
Only listen on ldapi:/// during bootstrapping

### DIFF
--- a/image/service/slapd/startup.sh
+++ b/image/service/slapd/startup.sh
@@ -305,11 +305,11 @@ EOF
 
     # start OpenLDAP
     log-helper info "Start OpenLDAP..."
-    # At this stage, we can just listen to ldap:// and ldap:// without naming any names
+    # At this stage, we can just listen to ldapi:// for localhost bootstrapping
     if log-helper level ge debug; then
-      slapd -h "ldap:/// ldapi:///" -u openldap -g openldap -d "$LDAP_LOG_LEVEL" 2>&1 &
+      slapd -h "ldapi:///" -u openldap -g openldap -d "$LDAP_LOG_LEVEL" 2>&1 &
     else
-      slapd -h "ldap:/// ldapi:///" -u openldap -g openldap
+      slapd -h "ldapi:///" -u openldap -g openldap
     fi
 
 


### PR DESCRIPTION
Currently, slapd listens on ldap:/// and ldapi:/// during
bootstrapping, which means that external connections to the
container can get accepted before the bootstrapping is complete.
This causes issues when using custom LDIF files, which may not
have fully processed by the time an external query is made.

This PR changes the startup.sh script to make slapd only listen on
ldapi:/// (effectively local-only access) during the bootstrapping
stage. This should also help when using Kubernetes readiness
probes, which may get prematurely triggered during the bootstrap
stage when the container should not be accepting connections.