### PR TITLE
Enable binding on IPv6

### DIFF
--- a/image/service/slapd/startup.sh
+++ b/image/service/slapd/startup.sh
@@ -576,6 +576,7 @@ else
 fi
 ETC_HOSTS=$(cat /etc/hosts | sed "/$HOSTNAME/d")
 echo "0.0.0.0 $FQDN_PARAM $HOSTNAME" > /etc/hosts
+echo ":: $FQDN_PARAM $HOSTNAME" >> /etc/hosts
 echo "$ETC_HOSTS" >> /etc/hosts
 
 exit 0


### PR DESCRIPTION
Credit for this should go to @telmich and his comments here:

https://github.com/osixia/docker-openldap/issues/607

This has solved "connection refused" errors in my k8s cluster trying to reach openldap via IPv6